### PR TITLE
Fix the filename for the IGOs part

### DIFF
--- a/bin/icann-reservedNames-to-text.php
+++ b/bin/icann-reservedNames-to-text.php
@@ -10,8 +10,10 @@ for ($i = 0 ; $i < $registries->length ; $i++) {
 	$registry = $registries->item($i);
 	$id = $registry->getAttribute('id');
 	if ('reservedNames' == $id) continue;
+	$fn = sprintf("S5.5-%s.txt", strtolower($id));
+	if ('igos' == strtolower($id)) $fn = 'S5.6.txt';
 
-	$fh = fopen(sprintf("S5.5-%s.txt", strtolower($id)), 'w');
+	$fh = fopen($fn, 'w');
 
 	$names = $registry->getElementsByTagName('name');
 	for ($j = 0 ; $j < $names->length ; $j++) fwrite($fh, $names->item($j)->textContent."\n");


### PR DESCRIPTION
According to README.md, "S5.6" is an expected file name for the IGOs part.
But current script generates "S5.5-igos" for it.
